### PR TITLE
Auto update workflow

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -1,9 +1,6 @@
 name: Prod Auto Update
 
 on:
-  push:
-    branches:
-      - auto_update
   workflow_dispatch:
   schedule:
     # Run workflow every 30 minutes

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -1,0 +1,45 @@
+name: Prod Auto Update
+
+on:
+  push:
+    branches:
+      - auto_update
+  workflow_dispatch:
+  schedule:
+    # Run workflow every 30 minutes
+    - cron: "*/30 * * * *"
+
+jobs:
+  auto_update:
+    runs-on: ubuntu-latest
+
+    # Run job for each semester
+    strategy:
+      matrix:
+        semester: [20210]
+
+    steps:
+      - name: Call course update route
+        id: update
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+          URL: https://rcos-orca.herokuapp.com
+          SEMESTER: ${{ matrix.semester }}
+        run: |
+          # Send POST request to production update route with API key in body
+          curl --data "api_key=$API_KEY" --silent --fail $URL/$SEMESTER/sections/update
+
+      - name: If update fail, create issue
+        if: ${{ failure() }}
+        uses: actions/github-script@v3
+        env:
+          SEMESTER: ${{ matrix.semester }}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Failed to update $SEMESTER",
+              labels: "bug"
+            })

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -32,14 +32,12 @@ jobs:
       - name: If update fail, create issue
         if: ${{ failure() }}
         uses: actions/github-script@v3
-        env:
-          SEMESTER: ${{ matrix.semester }}
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Failed to update $SEMESTER",
+              title: "Failed to update ${{ matrix.semester }}",
               labels: ["bug"]
             })

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -41,5 +41,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to update $SEMESTER",
-              labels: "bug"
+              labels: ["bug"]
             })

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -13,7 +13,7 @@ jobs:
     # Run job for each semester
     strategy:
       matrix:
-        semester: [20210]
+        semester: [202101]
 
     steps:
       - name: Call course update route


### PR DESCRIPTION
Adds a Github Action workflow `auto_update` that calls the semester update route every 30 minutes

@Apexal For the workflow to successfully function, it requires a repository secret `API_KEY` with the production api_key 

If the HTTP request fails, a Github issue is created with the title `Failed to update <semester_id>` and the `bug` label. 

Currently the semesters are hardcoded here:
```yaml
14    strategy:
15      matrix:
16        semester: [20210]
```

This uses the [matrix strategy](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) to run the `auto_update` job for each semester listed in the array. 

Unfortunately we'll need to update this by editing the workflow file :(
Another option could be to maybe provide it as a secret

Closes #9 